### PR TITLE
fix(helm): pod security fsgroup

### DIFF
--- a/charts/prmoji/README.md
+++ b/charts/prmoji/README.md
@@ -44,6 +44,8 @@ The SQLite file path is always `<persistence.mountPath>/prmoji.db`.
 
 It is not recommended to disable persistence, as it will lose all data on pod restart.
 
+The container runs as a **non-root** user; this chart sets `podSecurityContext.fsGroup=10001` by default so the mounted volume is writable across common storage classes.
+
 ### Cleanup Job
 
 A Job named `<release>-prmoji-cleanup` is created with `spec.suspend: true` by default.

--- a/charts/prmoji/values.yaml
+++ b/charts/prmoji/values.yaml
@@ -17,7 +17,8 @@ autoscaling:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  fsGroup: 10001
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
## Description
since the group mismatch, the process couldn't access the `/data` local volume
<!-- One line summary of the changes -->

## Testing
tested already, let's persist this as the default value
<!-- Describe how you tested this change - e.g. unit test only, tested in dev -->
