### PR TITLE
feat(emoji): use robot_face emoji for GitHub Copilot comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ SLACK_TOKEN='xoxb-...' ./prmoji run
 ### Emoji mapping
 
 - **commented** → `speech_balloon`
-- **commented by GitHub Copilot** → `copilot` *(custom emoji may be required in your Slack workspace)*
+- **commented by GitHub Copilot** → `robot_face`
 - **approved** → `white_check_mark`
 - **changes requested** → `no_entry`
 - **merged** → `pr-merged` *(custom emoji may be required in your Slack workspace)*

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ SLACK_TOKEN='xoxb-...' ./prmoji run
 ### Emoji mapping
 
 - **commented** → `speech_balloon`
+- **commented by GitHub Copilot** → `copilot` *(custom emoji may be required in your Slack workspace)*
 - **approved** → `white_check_mark`
 - **changes requested** → `no_entry`
 - **merged** → `pr-merged` *(custom emoji may be required in your Slack workspace)*

--- a/internal/github/events.go
+++ b/internal/github/events.go
@@ -20,6 +20,12 @@ type Classification struct {
 	Commenter string
 }
 
+// IsCopilot reports whether the given GitHub login belongs to GitHub Copilot,
+// e.g. "Copilot", "copilot-pull-request-reviewer[bot]" or "github-copilot[bot]".
+func IsCopilot(login string) bool {
+	return strings.Contains(strings.ToLower(login), "copilot")
+}
+
 func Classify(eventType string, body []byte) (Classification, bool) {
 	switch strings.ToLower(strings.TrimSpace(eventType)) {
 	case "issue_comment":

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -133,7 +133,7 @@ func (h *Handlers) processGitHubEvent(eventType string, body []byte) {
 		}
 	}
 
-	emoji := util.EmojiForAction(class.Action)
+	emoji := util.EmojiFor(class)
 	msgs, err := h.Store.ListMessagesByPRURL(ctx, class.PRURL)
 	if err != nil {
 		h.Log.Error("list messages failed", "err", err, "pr_url", class.PRURL)

--- a/internal/util/emoji.go
+++ b/internal/util/emoji.go
@@ -2,6 +2,16 @@ package util
 
 import "github.com/adamantal/prmoji/internal/github"
 
+// EmojiFor picks the Slack emoji for a classified GitHub event, taking the
+// commenter into account so that Copilot comments are distinguished from human
+// ones.
+func EmojiFor(c github.Classification) string {
+	if c.Action == github.ActionCommented && github.IsCopilot(c.Commenter) {
+		return "copilot"
+	}
+	return EmojiForAction(c.Action)
+}
+
 func EmojiForAction(a github.Action) string {
 	switch a {
 	case github.ActionCommented:

--- a/internal/util/emoji.go
+++ b/internal/util/emoji.go
@@ -7,7 +7,7 @@ import "github.com/adamantal/prmoji/internal/github"
 // ones.
 func EmojiFor(c github.Classification) string {
 	if c.Action == github.ActionCommented && github.IsCopilot(c.Commenter) {
-		return "copilot"
+		return "robot_face"
 	}
 	return EmojiForAction(c.Action)
 }

--- a/internal/util/emoji_test.go
+++ b/internal/util/emoji_test.go
@@ -13,9 +13,9 @@ func TestEmojiFor_CopilotComment(t *testing.T) {
 		want      string
 	}{
 		{"human comment", "bob", "speech_balloon"},
-		{"copilot display name", "Copilot", "copilot"},
-		{"copilot reviewer bot", "copilot-pull-request-reviewer[bot]", "copilot"},
-		{"github copilot bot", "github-copilot[bot]", "copilot"},
+		{"copilot display name", "Copilot", "robot_face"},
+		{"copilot reviewer bot", "copilot-pull-request-reviewer[bot]", "robot_face"},
+		{"github copilot bot", "github-copilot[bot]", "robot_face"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/util/emoji_test.go
+++ b/internal/util/emoji_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/adamantal/prmoji/internal/github"
+)
+
+func TestEmojiFor_CopilotComment(t *testing.T) {
+	cases := []struct {
+		name      string
+		commenter string
+		want      string
+	}{
+		{"human comment", "bob", "speech_balloon"},
+		{"copilot display name", "Copilot", "copilot"},
+		{"copilot reviewer bot", "copilot-pull-request-reviewer[bot]", "copilot"},
+		{"github copilot bot", "github-copilot[bot]", "copilot"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EmojiFor(github.Classification{Action: github.ActionCommented, Commenter: tc.commenter})
+			if got != tc.want {
+				t.Fatalf("expected %q got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestEmojiFor_CopilotOnlyAffectsComments(t *testing.T) {
+	// A Copilot approval should still use the approval emoji, not the copilot one.
+	got := EmojiFor(github.Classification{Action: github.ActionApproved, Commenter: "Copilot"})
+	if got != "white_check_mark" {
+		t.Fatalf("expected white_check_mark got %q", got)
+	}
+}


### PR DESCRIPTION
## What

When GitHub Copilot comments on a PR, prmoji now reacts on Slack with the built-in `:robot_face:` emoji instead of the generic `:speech_balloon:`, so it's clear the comment came from Copilot rather than a human.

## How

- `github.IsCopilot(login)` recognises Copilot's GitHub identities (`Copilot`, `copilot-pull-request-reviewer[bot]`, `github-copilot[bot]`), case-insensitively.
- New `util.EmojiFor(class)` returns `robot_face` when the action is `commented` **and** the commenter is Copilot; otherwise it falls back to the existing `EmojiForAction`.
- The handler now calls `util.EmojiFor(class)`.
- Added unit tests covering Copilot detection and that only `commented` events are affected (a Copilot approval still uses `white_check_mark`).
- README emoji mapping updated.

## Notes

- Uses the standard `:robot_face:` Slack emoji, so no custom emoji upload is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)